### PR TITLE
art: fix dex2oat watchdog timeout

### DIFF
--- a/dex2oat/dex2oat.cc
+++ b/dex2oat/dex2oat.cc
@@ -436,10 +436,10 @@ class WatchDog {
   // Debug builds are slower so they have larger timeouts.
   static constexpr int64_t kSlowdownFactor = kIsDebugBuild ? 5U : 1U;
 
-  // 9.5 minutes scaled by kSlowdownFactor. This is slightly smaller than the Package Manager
-  // watchdog (PackageManagerService.WATCHDOG_TIMEOUT, 10 minutes), so that dex2oat will abort
+  // 59.5 minutes scaled by kSlowdownFactor. This is slightly smaller than the Package Manager
+  // watchdog (PackageManagerService.WATCHDOG_TIMEOUT, 60 minutes), so that dex2oat will abort
   // itself before that watchdog would take down the system server.
-  static constexpr int64_t kWatchDogTimeoutSeconds = kSlowdownFactor * (9 * 60 + 30);
+  static constexpr int64_t kWatchDogTimeoutSeconds = kSlowdownFactor * (59 * 60 + 30);
 
   bool is_watch_dog_enabled_;
   bool shutting_down_;


### PR DESCRIPTION
Merging of Android 6.0.1 release 3 (Change-Id:
I23fd56f2c1a3e8e8b993a151a794e18f3569912e) reverted the watchdog
timeout back to old short one.

PackageManagerService in frameworks/base/ is still using 60 minutes as
watchdog timeout (Change-Id: Ia8f089ea340f21023abb8a58ddb3aede8b2b728c)
and I think this should match that or revert PackageManagerService side
back to also using 10-minute timeout as documented here on dex2oat.

I modified the old long timeout to match the change from 6.0.1_r3 merge
(Change-Id: I425b19ab305cfaa43f6bddc3a892be892acaf513) which introduced
slightly shorter (30 seconds) timeout here to make sure that "dex2oat
kills itself before the system server watchdog kills the system because
of the long installation".

Change-Id: I79e4bed34df7d964b9c4cac0d1c344cf773961b7
