### PR TITLE
ART: make ART extension available only in 32bit for msm8996

### DIFF
--- a/compiler/Android.mk
+++ b/compiler/Android.mk
@@ -271,7 +271,11 @@ $$(ENUM_OPERATOR_OUT_GEN): $$(GENERATED_SRC_DIR)/%_operator_out.cc : $(LOCAL_PAT
     ifeq ($(TARGET_HAVE_QC_PERF),true)
 	  # FIXME! Current PERF is built with GCC and needs emutls
       LOCAL_CLANG := false
-      LOCAL_WHOLE_STATIC_LIBRARIES += libqc-art-compiler
+      ifeq ($(TARGET_BOARD_PLATFORM),msm8996)
+        LOCAL_WHOLE_STATIC_LIBRARIES_arm += libqc-art-compiler
+      else
+        LOCAL_WHOLE_STATIC_LIBRARIES += libqc-art-compiler
+      endif
     endif
     include $(BUILD_SHARED_LIBRARY)
   else # host


### PR DESCRIPTION
Original:
https://www.codeaurora.org/cgit/quic/la/platform/art/commit/?h=LA.AF.1.1.1&id=ac245aa125188026590ac0092c212dd5cff11e5b

Change-Id: Ic5ac941f5427a1d6340635fdd81308dc639f3fc8
